### PR TITLE
Added extra lables and removed the hardcoded job name

### DIFF
--- a/alloy/windows/config.alloy
+++ b/alloy/windows/config.alloy
@@ -13,7 +13,17 @@ discovery.relabel "integrations_windows_exporter" {
 
   rule {
     target_label = "instance"
-    replacement  = constants.hostname
+    replacement  = {HOSTNAME}
+  }
+
+  rule {
+    target_label = "cluster"
+    replacement  = {DUPLO_TENANT_NAME}
+  }
+
+  rule {
+    target_label = "tenant"
+    replacement  = {DUPLO_TENANT_NAME}
   }
 }
 
@@ -69,7 +79,7 @@ loki.source.windowsevent "logs_integrations_windows_exporter_application" {
   use_incoming_timestamp = true
   forward_to             = [loki.relabel.logs_integrations_windows_exporter_application.receiver]
   labels                 = {
-    instance = constants.hostname,
+    instance = {HOSTNAME},
     job      = "integrations/windows_exporter",
   }
 }
@@ -109,7 +119,7 @@ loki.source.windowsevent "logs_integrations_windows_exporter_system" {
   use_incoming_timestamp = true
   forward_to             = [loki.relabel.logs_integrations_windows_exporter_system.receiver]
   labels                 = {
-    instance = constants.hostname,
+    instance = {HOSTNAME},
     job      = "integrations/windows_exporter",
   }
 }
@@ -126,11 +136,18 @@ loki.source.file "application_logs" {
 
 loki.process "logs_service" {
   stage.static_labels {
-      values = {
-        instance = constants.hostname,
-        job      = "integrations/windows_custom_logs",
-      }
+    values = {
+      instance = {HOSTNAME},
+      cluster = {DUPLO_TENANT_NAME},
+      tenant = {DUPLO_TENANT_NAME}
+    }
   }
+
+  stage.match {
+		selector = "{job=\"integrations/iis\"} |~ \"^#\""
+		action = "drop"
+		drop_counter_reason = "iis_comment_line"
+	}
 
   forward_to = [loki.write.logs_service.receiver]
 }

--- a/alloy/windows/script/install-windows-alloy.ps1
+++ b/alloy/windows/script/install-windows-alloy.ps1
@@ -2,7 +2,9 @@
 param (
     $DUPLO_LOGGING_PATHS,
     $DUPLO_METRICS_URL,
-    $DUPLO_LOGGING_URL
+    $DUPLO_LOGGING_URL,
+    $DUPLO_TENANT_NAME,
+    $HOSTNAME
 )
 
 # Sets the default TLS version to 1.2 to avoid issues downloading the Alloy installer on some networks
@@ -31,10 +33,22 @@ if ($DUPLO_LOGGING_URL -eq $null -or $DUPLO_LOGGING_URL -eq "") {
     exit 1
 }
 
+if ($DUPLO_TENANT_NAME -eq $null -or $DUPLO_TENANT_NAME -eq "") {
+    Write-Host "ERROR: Required argument DUPLO_TENANT_NAME missing"
+    exit 1
+}
+
+if ($HOSTNAME -eq $null -or $HOSTNAME -eq "") {
+    Write-Host "ERROR: Required argument HOSTNAME missing"
+    exit 1
+}
+
 try {
     Write-Host "DUPLO_LOGGING_PATHS:" $DUPLO_LOGGING_PATHS
     Write-Host "DUPLO_METRICS_URL:" $DUPLO_METRICS_URL
     Write-Host "DUPLO_LOGGING_URL:" $DUPLO_LOGGING_URL
+    Write-Host "DUPLO_TENANT_NAME:" $DUPLO_TENANT_NAME
+    Write-Host "HOSTNAME:" $HOSTNAME
 
     Write-Host "Downloading Alloy Windows Installer"
     $DOWNLOAD_URL = "https://github.com/grafana/alloy/releases/download/v1.4.3/alloy-installer-windows-amd64.exe.zip"
@@ -75,6 +89,8 @@ try {
     $content = $content.Replace("{DUPLO_LOGGING_PATHS}", $DUPLO_LOGGING_PATHS)
     $content = $content.Replace("{DUPLO_METRICS_URL}", $DUPLO_METRICS_URL)
     $content = $content.Replace("{DUPLO_LOGGING_URL}", $DUPLO_LOGGING_URL)
+    $content = $content.Replace("{DUPLO_TENANT_NAME}", $DUPLO_TENANT_NAME)
+    $content = $content.Replace("{HOSTNAME}", $HOSTNAME)
     $content | Set-Content $CONFIG_FILE
 
     $DEST_DIR = "C:\Program Files\GrafanaLabs\Alloy"


### PR DESCRIPTION
now job should be part of the loggging path as below. Also  DUPLO_TENANT_NAME and HOSTNAME is required as a part of params in script.

[{
	__address__ = "localhost",
	__path__    = "/inetpub/logs/LogFiles/W3SVC<site1-id>/u_ex*.log",
	job         = "integrations/iis" or "integrations/windows_exporter" or  "<tenant-name/app_name>",
	site        = "<your-site1-name>",
}]