### PR TITLE
DUPLO-37824 Add regex to parse QueueName

### DIFF
--- a/integrations/integration-aws-cloudwatch/provisioning/dashboard-aws-sqs.yaml
+++ b/integrations/integration-aws-cloudwatch/provisioning/dashboard-aws-sqs.yaml
@@ -682,7 +682,7 @@ spec:
                     TENANT_NAME:
                         - $tenant
               refresh: 1
-              regex: ""
+              regex: "/([^:]+)$/"
               skipUrlSync: false
               sort: 0
               type: query


### PR DESCRIPTION
Adds regex to parse QueueName so that it's not the ARN displayed or used which will not query data correctly.