### PR TITLE
New Grafana version default receiver

### DIFF
--- a/integrations/integration-duplo-bootstrap/provisioning/duplo-notification-policy.yaml
+++ b/integrations/integration-duplo-bootstrap/provisioning/duplo-notification-policy.yaml
@@ -6,7 +6,7 @@ spec:
   group_by:
     - grafana_folder
     - alertname
-  receiver: grafana-default-email
+  receiver: empty
   orgId: 1
   routes:
     - object_matchers:


### PR DESCRIPTION
New Grafana version default receiver if we'll not update this bootstrap job will fail.