### PR TITLE
feat: Grafana DB lock error monitoring

### DIFF
--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -459,7 +459,7 @@ def collect_grafana_db_lock_errors(labels: Dict[str, str]) -> Dict[str, Any]:
     service = 'grafana-ui'
 
     source_loki_url = f"http://duplo-logging-gateway.{namespace}.svc.cluster.local"
-    query = f'sum(count_over_time({{namespace="{namespace}", service_name="{service}"}} |= `database is locked` |= `logger=sqlstore` [24h]))'
+    query = f'sum(count_over_time({{namespace="{namespace}", service_name="{service}"}} |= `database is locked` != `logger=tsdb` [24h]))'
 
     data = query_loki(source_loki_url, query)
 

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -755,6 +755,29 @@ def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict, cred
     else:
         logger.warning("No Loki messages were sent! All data may have been empty or filtered out.")
 
+def find_active_prometheus_tenant(prometheus_url: str, tenants: List[Dict[str, str]]) -> Optional[Dict[str, str]]:
+    """
+    Try each Prometheus tenant with a lightweight query and return the first one
+    that returns data. Falls back to None (no auth) if no tenants or none return data.
+    """
+    if not tenants:
+        logger.info("No Prometheus tenants discovered — using single-tenant mode")
+        return None
+
+    probe_query = 'count(up)'
+    for credentials in tenants:
+        username = credentials.get('username')
+        password = credentials.get('password')
+        response = query_prometheus(prometheus_url, probe_query, username, password)
+        if response and response.get('data', {}).get('result'):
+            logger.info(f"Active Prometheus tenant found: {username}")
+            return credentials
+        logger.info(f"Prometheus tenant '{username}' returned no data, trying next")
+
+    logger.warning("No active Prometheus tenant found — falling back to no auth")
+    return None
+
+
 def main() -> None:
     """
     Main function that orchestrates the monitoring data collection process.
@@ -780,13 +803,15 @@ def main() -> None:
     prometheus_tenants = get_tenant_credentials(namespace, 'metricsservice')
     loki_tenants = get_tenant_credentials(namespace, 'logsservice')
 
-    # Prometheus collections — run per tenant (or once in single-tenant mode)
-    for credentials in (prometheus_tenants or [None]):
-        collect_and_send_version_data(prometheus_url, labels, credentials)
-        collect_and_send_grafana_usage(prometheus_url, labels, credentials)
-        collect_and_send_otel_pod_node_usage(prometheus_url, labels, credentials)
+    # Find the first Prometheus tenant that returns data
+    prometheus_creds = find_active_prometheus_tenant(prometheus_url, prometheus_tenants)
 
-    # Loki collections — run per tenant (or once in single-tenant mode)
+    # Prometheus collections — run once with the active tenant's credentials
+    collect_and_send_version_data(prometheus_url, labels, prometheus_creds)
+    collect_and_send_grafana_usage(prometheus_url, labels, prometheus_creds)
+    collect_and_send_otel_pod_node_usage(prometheus_url, labels, prometheus_creds)
+
+    # Loki collections — query all tenants, aggregate into single count
     collect_and_send_grafana_db_lock_errors(labels, loki_tenants or None)
     
     logger.info("Completed monitoring data collection")

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -447,8 +447,8 @@ def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str]) -> None:
 
     namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
     service = 'grafana-ui'
-    username = os.getenv('SOURCE_LOKI_USERNAME')
-    password = os.getenv('SOURCE_LOKI_PASSWORD')
+    username = os.getenv('SOURCE_LOKI_USERNAME', '').strip() or None
+    password = os.getenv('SOURCE_LOKI_PASSWORD', '').strip() or None
 
     source_loki_url = os.getenv('SOURCE_LOKI_URL') or f"http://duplo-logging-gateway.{namespace}.svc.cluster.local"
     query = f'sum(count_over_time({{namespace="{namespace}", service_name="{service}"}} |= `database is locked` != `logger=tsdb` [24h]))'
@@ -716,10 +716,9 @@ def main() -> None:
     
     # Get configuration from environment
     prometheus_url = os.getenv('PROMETHEUS_URL')
-    prometheus_creds = {
-        'username': os.getenv('SOURCE_PROMETHEUS_USERNAME', ''),
-        'password': os.getenv('SOURCE_PROMETHEUS_PASSWORD', '')
-    } if os.getenv('SOURCE_PROMETHEUS_USERNAME') else None
+    prom_user = os.getenv('SOURCE_PROMETHEUS_USERNAME', '').strip()
+    prom_pass = os.getenv('SOURCE_PROMETHEUS_PASSWORD', '').strip()
+    prometheus_creds = {'username': prom_user, 'password': prom_pass} if prom_user and prom_pass else None
 
     # Collect and send data
     collect_and_send_version_data(prometheus_url, labels, prometheus_creds)

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -480,10 +480,10 @@ def query_loki(loki_url: str, query: str, username: Optional[str] = None, passwo
         return None
 
 
-def collect_grafana_db_lock_errors(labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+def collect_grafana_db_lock_errors(labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> int:
     """
-    Count 'database is locked' errors in grafana-ui logs over the last 24h.
-    Accepts optional Loki tenant credentials for multi-tenant setups.
+    Count 'database is locked' errors in grafana-ui logs over the last 24h for one tenant.
+    Returns the integer count. Caller is responsible for aggregating across tenants.
     """
     logger.info("Collecting Grafana DB lock error count")
 
@@ -505,30 +505,30 @@ def collect_grafana_db_lock_errors(labels: Dict[str, str], credentials: Optional
             logger.error(f"Error parsing Loki DB lock count: {e}")
 
     logger.info(f"Grafana DB lock error count (last 24h): {count} (tenant: {username or 'single-tenant'})")
-    result = {
-        "namespace": namespace,
-        "service": service,
-        "db_lock_error_count_24h": count
-    }
-    if username:
-        result["tenant"] = username
-    return result
+    return count
 
 
 def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str], loki_tenants: Optional[List[Dict[str, str]]] = None) -> None:
     """
     Collect Grafana DB lock error count from source Loki and send to central Loki.
-    Iterates per tenant in multi-tenant setups; falls back to single-tenant if no tenants provided.
+    Queries all Loki tenants and aggregates into a single count — Grafana is one shared
+    service in the otel namespace, its logs exist in only one tenant but we sum across
+    all to avoid needing to know which tenant holds otel namespace logs.
     """
     logger.info("Collecting and sending Grafana DB lock error data")
 
     tenants = loki_tenants or [None]
-    current_time = str(int(time.time() * 1_000_000_000))
-    values = []
+    total_count = sum(collect_grafana_db_lock_errors(labels, creds) for creds in tenants)
 
-    for credentials in tenants:
-        result = collect_grafana_db_lock_errors(labels, credentials)
-        values.append([current_time, json.dumps(result)])
+    logger.info(f"Grafana DB lock error total count (last 24h, all tenants): {total_count}")
+
+    namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
+    current_time = str(int(time.time() * 1_000_000_000))
+    values = [[current_time, json.dumps({
+        "namespace": namespace,
+        "service": "grafana-ui",
+        "db_lock_error_count_24h": total_count
+    })]]
 
     send_to_loki(
         "grafana_db_lock_errors",

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -6,7 +6,6 @@ This script collects monitoring data from Prometheus and sends it to Loki.
 It extracts information about monitoring components, their images, and Grafana usage.
 """
 
-import base64
 import json
 import logging
 import os
@@ -24,47 +23,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-
-def get_tenant_credentials(namespace: str, secret_prefix: str) -> List[Dict[str, str]]:
-    """
-    Discover tenant credentials from k8s secrets matching <secret_prefix>*-duplo-monitoring-k8s-monitoring.
-    Uses the in-cluster service account token. Returns empty list if unavailable (single-tenant mode).
-    """
-    token_path = '/var/run/secrets/kubernetes.io/serviceaccount/token'
-    ca_path = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
-
-    if not os.path.exists(token_path):
-        logger.info("No service account token found — running in single-tenant mode")
-        return []
-
-    try:
-        with open(token_path) as f:
-            token = f.read().strip()
-
-        response = requests.get(
-            f"https://kubernetes.default.svc/api/v1/namespaces/{namespace}/secrets",
-            headers={'Authorization': f'Bearer {token}'},
-            verify=ca_path
-        )
-        response.raise_for_status()
-
-        tenants = []
-        suffix = '-duplo-monitoring-k8s-monitoring'
-        for item in response.json().get('items', []):
-            name = item['metadata']['name']
-            if name.startswith(secret_prefix) and name.endswith(suffix):
-                data = item.get('data', {})
-                username = base64.b64decode(data['username']).decode() if 'username' in data else ''
-                password = base64.b64decode(data['password']).decode() if 'password' in data else ''
-                if username and password:
-                    tenants.append({'username': username, 'password': password})
-                    logger.info(f"Discovered tenant: {username}")
-
-        logger.info(f"Found {len(tenants)} tenant(s) for prefix '{secret_prefix}'")
-        return tenants
-    except Exception as e:
-        logger.warning(f"Could not discover tenant credentials for prefix '{secret_prefix}': {e}")
-        return []
 
 
 def query_prometheus(prometheus_url: str, query: str, username: Optional[str] = None, password: Optional[str] = None) -> Optional[Dict[str, Any]]:
@@ -480,17 +438,17 @@ def query_loki(loki_url: str, query: str, username: Optional[str] = None, passwo
         return None
 
 
-def collect_grafana_db_lock_errors(labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> int:
+def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str]) -> None:
     """
-    Count 'database is locked' errors in grafana-ui logs over the last 24h for one tenant.
-    Returns the integer count. Caller is responsible for aggregating across tenants.
+    Count 'database is locked' errors in grafana-ui logs over the last 24h and send to central Loki.
+    Source Loki credentials from SOURCE_LOKI_USERNAME / SOURCE_LOKI_PASSWORD env vars (optional).
     """
-    logger.info("Collecting Grafana DB lock error count")
+    logger.info("Collecting and sending Grafana DB lock error data")
 
     namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
     service = 'grafana-ui'
-    username = credentials.get('username') if credentials else None
-    password = credentials.get('password') if credentials else None
+    username = os.getenv('SOURCE_LOKI_USERNAME')
+    password = os.getenv('SOURCE_LOKI_PASSWORD')
 
     source_loki_url = os.getenv('SOURCE_LOKI_URL') or f"http://duplo-logging-gateway.{namespace}.svc.cluster.local"
     query = f'sum(count_over_time({{namespace="{namespace}", service_name="{service}"}} |= `database is locked` != `logger=tsdb` [24h]))'
@@ -504,30 +462,13 @@ def collect_grafana_db_lock_errors(labels: Dict[str, str], credentials: Optional
         except (KeyError, IndexError, ValueError) as e:
             logger.error(f"Error parsing Loki DB lock count: {e}")
 
-    logger.info(f"Grafana DB lock error count (last 24h): {count} (tenant: {username or 'single-tenant'})")
-    return count
+    logger.info(f"Grafana DB lock error count (last 24h): {count}")
 
-
-def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str], loki_tenants: Optional[List[Dict[str, str]]] = None) -> None:
-    """
-    Collect Grafana DB lock error count from source Loki and send to central Loki.
-    Queries all Loki tenants and aggregates into a single count — Grafana is one shared
-    service in the otel namespace, its logs exist in only one tenant but we sum across
-    all to avoid needing to know which tenant holds otel namespace logs.
-    """
-    logger.info("Collecting and sending Grafana DB lock error data")
-
-    tenants = loki_tenants or [None]
-    total_count = sum(collect_grafana_db_lock_errors(labels, creds) for creds in tenants)
-
-    logger.info(f"Grafana DB lock error total count (last 24h, all tenants): {total_count}")
-
-    namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
     current_time = str(int(time.time() * 1_000_000_000))
     values = [[current_time, json.dumps({
         "namespace": namespace,
-        "service": "grafana-ui",
-        "db_lock_error_count_24h": total_count
+        "service": service,
+        "db_lock_error_count_24h": count
     })]]
 
     send_to_loki(
@@ -755,28 +696,6 @@ def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict, cred
     else:
         logger.warning("No Loki messages were sent! All data may have been empty or filtered out.")
 
-def find_active_prometheus_tenant(prometheus_url: str, tenants: List[Dict[str, str]]) -> Optional[Dict[str, str]]:
-    """
-    Try each Prometheus tenant with a lightweight query and return the first one
-    that returns data. Falls back to None (no auth) if no tenants or none return data.
-    """
-    if not tenants:
-        logger.info("No Prometheus tenants discovered — using single-tenant mode")
-        return None
-
-    probe_query = 'count(up)'
-    for credentials in tenants:
-        username = credentials.get('username')
-        password = credentials.get('password')
-        response = query_prometheus(prometheus_url, probe_query, username, password)
-        if response and response.get('data', {}).get('result'):
-            logger.info(f"Active Prometheus tenant found: {username}")
-            return credentials
-        logger.info(f"Prometheus tenant '{username}' returned no data, trying next")
-
-    logger.warning("No active Prometheus tenant found — falling back to no auth")
-    return None
-
 
 def main() -> None:
     """
@@ -797,22 +716,16 @@ def main() -> None:
     
     # Get configuration from environment
     prometheus_url = os.getenv('PROMETHEUS_URL')
-    namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
+    prometheus_creds = {
+        'username': os.getenv('PROMETHEUS_USERNAME', ''),
+        'password': os.getenv('PROMETHEUS_PASSWORD', '')
+    } if os.getenv('PROMETHEUS_USERNAME') else None
 
-    # Discover tenants dynamically from k8s secrets (empty list = single-tenant mode)
-    prometheus_tenants = get_tenant_credentials(namespace, 'metricsservice')
-    loki_tenants = get_tenant_credentials(namespace, 'logsservice')
-
-    # Find the first Prometheus tenant that returns data
-    prometheus_creds = find_active_prometheus_tenant(prometheus_url, prometheus_tenants)
-
-    # Prometheus collections — run once with the active tenant's credentials
+    # Collect and send data
     collect_and_send_version_data(prometheus_url, labels, prometheus_creds)
     collect_and_send_grafana_usage(prometheus_url, labels, prometheus_creds)
     collect_and_send_otel_pod_node_usage(prometheus_url, labels, prometheus_creds)
-
-    # Loki collections — query all tenants, aggregate into single count
-    collect_and_send_grafana_db_lock_errors(labels, loki_tenants or None)
+    collect_and_send_grafana_db_lock_errors(labels)
     
     logger.info("Completed monitoring data collection")
 

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -299,7 +299,7 @@ def validate_environment_variables() -> Tuple[bool, Dict[str, str], List[str]]:
     
     # Validate required environment variables
     required_vars = [
-        'PROMETHEUS_URL', 'LOKI_URL', 'CLUSTER', 'NAMESPACE', 
+        'PROMETHEUS_URL', 'LOKI_URL', 'CLUSTER', 'NAMESPACE',
         'CUSTOMER', 'ENVIRONMENT', 'DUPLO_URL'
     ]
     missing_vars = [var for var in required_vars if not os.getenv(var)]
@@ -426,6 +426,77 @@ def collect_and_send_grafana_usage(prometheus_url: str, labels: Dict[str, str]) 
     # Format and send Grafana usage data
     format_and_send_grafana_usage_data(grafana_usage, labels)
     logger.info("Completed Grafana usage data collection and sending")
+
+def query_loki(loki_url: str, query: str, username: Optional[str] = None, password: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """
+    Run a LogQL instant metric query against Loki and return the response.
+    """
+    try:
+        logger.info(f"Querying Loki with query: {query}")
+        auth = (username, password) if username and password else None
+        response = requests.get(
+            f"{loki_url}/loki/api/v1/query",
+            params={'query': query},
+            auth=auth
+        )
+        response.raise_for_status()
+        logger.debug("Successfully received response from Loki")
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error querying Loki: {e}")
+        return None
+
+
+def collect_grafana_db_lock_errors(labels: Dict[str, str]) -> Dict[str, Any]:
+    """
+    Count 'database is locked' errors in grafana-ui logs over the last 24h.
+
+    Returns a dict with the count and metadata, ready to send to central Loki.
+    """
+    logger.info("Collecting Grafana DB lock error count")
+
+    namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
+    service = 'grafana-ui'
+
+    source_loki_url = f"http://duplo-logging-gateway.{namespace}.svc.cluster.local"
+    query = f'sum(count_over_time({{namespace="{namespace}", service_name="{service}"}} |= `database is locked` |= `logger=sqlstore` [24h]))'
+
+    data = query_loki(source_loki_url, query)
+
+    count = 0
+    if data and 'data' in data and 'result' in data['data'] and data['data']['result']:
+        try:
+            count = int(float(data['data']['result'][0]['value'][1]))
+        except (KeyError, IndexError, ValueError) as e:
+            logger.error(f"Error parsing Loki DB lock count: {e}")
+
+    logger.info(f"Grafana DB lock error count (last 24h): {count}")
+    return {
+        "namespace": namespace,
+        "service": service,
+        "db_lock_error_count_24h": count
+    }
+
+
+def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str]) -> None:
+    """
+    Collect Grafana DB lock error count from source Loki and send to central Loki.
+    """
+    logger.info("Collecting and sending Grafana DB lock error data")
+
+    result = collect_grafana_db_lock_errors(labels)
+
+    current_time = str(int(time.time() * 1_000_000_000))
+    values = [[current_time, json.dumps(result)]]
+
+    send_to_loki(
+        "grafana_db_lock_errors",
+        "loki",
+        "db_lock_error_count_24h",
+        values
+    )
+    logger.info("Completed Grafana DB lock error data collection and sending")
+
 
 def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict) -> None:
     """
@@ -660,11 +731,12 @@ def main() -> None:
     
     # Get configuration from environment
     prometheus_url = os.getenv('PROMETHEUS_URL')
-    
+
     # Collect and send data to Loki
     collect_and_send_version_data(prometheus_url, labels)
     collect_and_send_grafana_usage(prometheus_url, labels)
     collect_and_send_otel_pod_node_usage(prometheus_url, labels)
+    collect_and_send_grafana_db_lock_errors(labels)
     
     logger.info("Completed monitoring data collection")
 

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -717,9 +717,9 @@ def main() -> None:
     # Get configuration from environment
     prometheus_url = os.getenv('PROMETHEUS_URL')
     prometheus_creds = {
-        'username': os.getenv('PROMETHEUS_USERNAME', ''),
-        'password': os.getenv('PROMETHEUS_PASSWORD', '')
-    } if os.getenv('PROMETHEUS_USERNAME') else None
+        'username': os.getenv('SOURCE_PROMETHEUS_USERNAME', ''),
+        'password': os.getenv('SOURCE_PROMETHEUS_PASSWORD', '')
+    } if os.getenv('SOURCE_PROMETHEUS_USERNAME') else None
 
     # Collect and send data
     collect_and_send_version_data(prometheus_url, labels, prometheus_creds)

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -6,6 +6,7 @@ This script collects monitoring data from Prometheus and sends it to Loki.
 It extracts information about monitoring components, their images, and Grafana usage.
 """
 
+import base64
 import json
 import logging
 import os
@@ -24,22 +25,68 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def query_prometheus(prometheus_url: str, query: str) -> Optional[Dict[str, Any]]:
+def get_tenant_credentials(namespace: str, secret_prefix: str) -> List[Dict[str, str]]:
+    """
+    Discover tenant credentials from k8s secrets matching <secret_prefix>*-duplo-monitoring-k8s-monitoring.
+    Uses the in-cluster service account token. Returns empty list if unavailable (single-tenant mode).
+    """
+    token_path = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+    ca_path = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+
+    if not os.path.exists(token_path):
+        logger.info("No service account token found — running in single-tenant mode")
+        return []
+
+    try:
+        with open(token_path) as f:
+            token = f.read().strip()
+
+        response = requests.get(
+            f"https://kubernetes.default.svc/api/v1/namespaces/{namespace}/secrets",
+            headers={'Authorization': f'Bearer {token}'},
+            verify=ca_path
+        )
+        response.raise_for_status()
+
+        tenants = []
+        suffix = '-duplo-monitoring-k8s-monitoring'
+        for item in response.json().get('items', []):
+            name = item['metadata']['name']
+            if name.startswith(secret_prefix) and name.endswith(suffix):
+                data = item.get('data', {})
+                username = base64.b64decode(data['username']).decode() if 'username' in data else ''
+                password = base64.b64decode(data['password']).decode() if 'password' in data else ''
+                if username and password:
+                    tenants.append({'username': username, 'password': password})
+                    logger.info(f"Discovered tenant: {username}")
+
+        logger.info(f"Found {len(tenants)} tenant(s) for prefix '{secret_prefix}'")
+        return tenants
+    except Exception as e:
+        logger.warning(f"Could not discover tenant credentials for prefix '{secret_prefix}': {e}")
+        return []
+
+
+def query_prometheus(prometheus_url: str, query: str, username: Optional[str] = None, password: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """
     Query Prometheus and return the response.
-    
+
     Args:
         prometheus_url: URL of the Prometheus instance
         query: PromQL query to execute
-        
+        username: Optional basic auth username (for multi-tenant Mimir)
+        password: Optional basic auth password (for multi-tenant Mimir)
+
     Returns:
         JSON response from Prometheus or None if the query fails
     """
     try:
         logger.info(f"Querying Prometheus with query: {query}")
+        auth = (username, password) if username and password else None
         response = requests.get(
             f"{prometheus_url}/api/v1/query",
-            params={'query': query}
+            params={'query': query},
+            auth=auth
         )
         response.raise_for_status()
         logger.debug("Successfully received response from Prometheus")
@@ -311,32 +358,32 @@ def validate_environment_variables() -> Tuple[bool, Dict[str, str], List[str]]:
     return True, labels, []
 
 
-def collect_image_versions(prometheus_url: str, labels: Dict[str, str]) -> Optional[Dict[str, Dict[str, Dict[str, Dict[str, str]]]]]:
+def collect_image_versions(prometheus_url: str, labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> Optional[Dict[str, Dict[str, Dict[str, Dict[str, str]]]]]:
     """
     Collect image versions for monitoring components from Prometheus.
-    
+
     Args:
         prometheus_url: URL of the Prometheus instance
         labels: Dictionary containing additional labels
-        
+        credentials: Optional dict with 'username' and 'password' for multi-tenant Mimir
+
     Returns:
         Dictionary with image information categorized by cluster and namespace, then by 'main' and 'monitoring',
         or None if collection fails
     """
     logger.info("Collecting image versions from Prometheus")
-    
-    # Get namespace filter from labels with fallback to default
+
     namespace_filter = labels.get('namespace_filter', '.*otel.*')
-    
-    # PromQL query for all components
+    username = credentials.get('username') if credentials else None
+    password = credentials.get('password') if credentials else None
+
     query = f'''
     count by(cluster, namespace, container, image, pod) (
       kube_pod_container_info{{namespace=~"{namespace_filter}", container!~"config-reloader|loki-sc-rules|memcached|gateway|exporter|kube-rbac-proxy|nginx|pushgateway"}}
     )
     '''
-    
-    # Query Prometheus for container images
-    prometheus_response = query_prometheus(prometheus_url, query)
+
+    prometheus_response = query_prometheus(prometheus_url, query, username, password)
     if not prometheus_response:
         logger.error("Failed to query Prometheus for image versions")
         return None
@@ -351,23 +398,25 @@ def collect_image_versions(prometheus_url: str, labels: Dict[str, str]) -> Optio
     return images
 
 
-def collect_grafana_usage(prometheus_url: str) -> Dict[str, int]:
+def collect_grafana_usage(prometheus_url: str, credentials: Optional[Dict[str, str]] = None) -> Dict[str, int]:
     """
     Collect Grafana datasource usage information from Prometheus.
-    
+
     Args:
         prometheus_url: URL of the Prometheus instance
-        
+        credentials: Optional dict with 'username' and 'password' for multi-tenant Mimir
+
     Returns:
         Dictionary with datasource names as keys and usage counts as values
     """
     logger.info("Collecting Grafana usage data")
-    
-    # PromQL query for Grafana datasource usage
+
+    username = credentials.get('username') if credentials else None
+    password = credentials.get('password') if credentials else None
+
     query = "sum by (datasource) (clamp_min(sum_over_time(clamp_min(increase(grafana_datasource_request_total[1h]), 0)[24h:1h]) - 24 * min_over_time(clamp_min(increase(grafana_datasource_request_total[1h]), 0)[24h:1h]), 0))"
 
-    # Query Prometheus for Grafana usage
-    data = query_prometheus(prometheus_url, query)
+    data = query_prometheus(prometheus_url, query, username, password)
     if not data:
         logger.warning("Could not fetch Grafana usage data from Prometheus")
         return {}
@@ -389,41 +438,25 @@ def collect_grafana_usage(prometheus_url: str) -> Dict[str, int]:
         return {}
 
 
-def collect_and_send_version_data(prometheus_url: str, labels: Dict[str, str]) -> None:
+def collect_and_send_version_data(prometheus_url: str, labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> None:
     """
     Collect image versions from Prometheus and send them to Loki.
-    
-    Args:
-        prometheus_url: URL of the Prometheus instance
-        labels: Dictionary containing additional labels
     """
     logger.info("Collecting and sending image data")
-    
-    # Collect image versions
-    images = collect_image_versions(prometheus_url, labels)
+    images = collect_image_versions(prometheus_url, labels, credentials)
     if not images:
         logger.error("Failed to collect image versions")
         return
-    
-    # Format and send image data
     format_and_send_image_data(images, labels)
     logger.info("Completed image data collection and sending")
 
 
-def collect_and_send_grafana_usage(prometheus_url: str, labels: Dict[str, str]) -> None:
+def collect_and_send_grafana_usage(prometheus_url: str, labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> None:
     """
     Collect Grafana usage data from Prometheus and send it to Loki.
-    
-    Args:
-        prometheus_url: URL of the Prometheus instance
-        labels: Dictionary containing additional labels
     """
     logger.info("Collecting and sending Grafana usage data")
-    
-    # Collect Grafana usage
-    grafana_usage = collect_grafana_usage(prometheus_url)
-    
-    # Format and send Grafana usage data
+    grafana_usage = collect_grafana_usage(prometheus_url, credentials)
     format_and_send_grafana_usage_data(grafana_usage, labels)
     logger.info("Completed Grafana usage data collection and sending")
 
@@ -447,21 +480,22 @@ def query_loki(loki_url: str, query: str, username: Optional[str] = None, passwo
         return None
 
 
-def collect_grafana_db_lock_errors(labels: Dict[str, str]) -> Dict[str, Any]:
+def collect_grafana_db_lock_errors(labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """
     Count 'database is locked' errors in grafana-ui logs over the last 24h.
-
-    Returns a dict with the count and metadata, ready to send to central Loki.
+    Accepts optional Loki tenant credentials for multi-tenant setups.
     """
     logger.info("Collecting Grafana DB lock error count")
 
     namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
     service = 'grafana-ui'
+    username = credentials.get('username') if credentials else None
+    password = credentials.get('password') if credentials else None
 
-    source_loki_url = f"http://duplo-logging-gateway.{namespace}.svc.cluster.local"
+    source_loki_url = os.getenv('SOURCE_LOKI_URL') or f"http://duplo-logging-gateway.{namespace}.svc.cluster.local"
     query = f'sum(count_over_time({{namespace="{namespace}", service_name="{service}"}} |= `database is locked` != `logger=tsdb` [24h]))'
 
-    data = query_loki(source_loki_url, query)
+    data = query_loki(source_loki_url, query, username, password)
 
     count = 0
     if data and 'data' in data and 'result' in data['data'] and data['data']['result']:
@@ -470,24 +504,31 @@ def collect_grafana_db_lock_errors(labels: Dict[str, str]) -> Dict[str, Any]:
         except (KeyError, IndexError, ValueError) as e:
             logger.error(f"Error parsing Loki DB lock count: {e}")
 
-    logger.info(f"Grafana DB lock error count (last 24h): {count}")
-    return {
+    logger.info(f"Grafana DB lock error count (last 24h): {count} (tenant: {username or 'single-tenant'})")
+    result = {
         "namespace": namespace,
         "service": service,
         "db_lock_error_count_24h": count
     }
+    if username:
+        result["tenant"] = username
+    return result
 
 
-def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str]) -> None:
+def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str], loki_tenants: Optional[List[Dict[str, str]]] = None) -> None:
     """
     Collect Grafana DB lock error count from source Loki and send to central Loki.
+    Iterates per tenant in multi-tenant setups; falls back to single-tenant if no tenants provided.
     """
     logger.info("Collecting and sending Grafana DB lock error data")
 
-    result = collect_grafana_db_lock_errors(labels)
-
+    tenants = loki_tenants or [None]
     current_time = str(int(time.time() * 1_000_000_000))
-    values = [[current_time, json.dumps(result)]]
+    values = []
+
+    for credentials in tenants:
+        result = collect_grafana_db_lock_errors(labels, credentials)
+        values.append([current_time, json.dumps(result)])
 
     send_to_loki(
         "grafana_db_lock_errors",
@@ -498,18 +539,20 @@ def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str]) -> None:
     logger.info("Completed Grafana DB lock error data collection and sending")
 
 
-def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict) -> None:
+def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict, credentials: Optional[Dict[str, str]] = None) -> None:
     """
     Collects 24h pod/node resource stats and otel_node_count for all clusters/namespaces;
     sends them in a *single* Loki push, one log-line per resource, in your requested JSON format.
     """
     logger.info("Collecting 24h OTEL pod/node usage statistics")
     namespace_regex = labels.get('namespace_filter', '.*otel.*')
+    username = credentials.get('username') if credentials else None
+    password = credentials.get('password') if credentials else None
 
     # 1. Excluded pods (DaemonSet/Job)
     def excluded_pods_by_owner_kind(kind):
         query = f'kube_pod_owner{{namespace=~"{namespace_regex}",owner_kind="{kind}"}}'
-        response = query_prometheus(prometheus_url, query) or {}
+        response = query_prometheus(prometheus_url, query, username, password) or {}
         return {(m['metric'].get('cluster'), m['metric'].get('namespace'), m['metric'].get('pod'))
                 for m in response.get("data", {}).get("result", [])}
 
@@ -520,7 +563,7 @@ def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict) -> N
     # 2. Pod-to-node mapping
     pod_to_node = {}
     pod_node_query = f'kube_pod_info{{namespace=~"{namespace_regex}"}}'
-    pod_node_response = query_prometheus(prometheus_url, pod_node_query) or {}
+    pod_node_response = query_prometheus(prometheus_url, pod_node_query, username, password) or {}
     for record in pod_node_response.get("data", {}).get("result", []):
         cluster = record['metric'].get('cluster')
         namespace = record['metric'].get('namespace')
@@ -531,7 +574,7 @@ def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict) -> N
 
     # 3. Node -> instance_type mapping
     instance_type_query = 'kube_node_labels{job="integrations/kubernetes/kube-state-metrics"}'
-    instance_type_data = query_prometheus(prometheus_url, instance_type_query) or {}
+    instance_type_data = query_prometheus(prometheus_url, instance_type_query, username, password) or {}
     node_instance_type = {}
     for res in instance_type_data.get("data", {}).get("result", []):
         cluster = res['metric'].get('cluster')
@@ -546,7 +589,7 @@ def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict) -> N
 
     # 4. Pod resource requests/limits
     def extract_pod_resource_usage(prometheus_query):
-        response = query_prometheus(prometheus_url, prometheus_query)
+        response = query_prometheus(prometheus_url, prometheus_query, username, password)
         result = {}
         if response and 'result' in response.get('data', {}):
             for record in response['data']['result']:
@@ -572,7 +615,7 @@ def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict) -> N
         "mem_min": f'min by (pod,namespace,cluster) (min_over_time(container_memory_rss{{{label_filter}}}[24h]))',
         "mem_max": f'max by (pod,namespace,cluster) (max_over_time(container_memory_rss{{{label_filter}}}[24h]))',
     }
-    pod_usage_stats = {k: query_prometheus(prometheus_url, query) for k, query in promql_templates.items()}
+    pod_usage_stats = {k: query_prometheus(prometheus_url, query, username, password) for k, query in promql_templates.items()}
 
     def usage_stat(stat, cluster, pod_name, namespace):
         for record in (pod_usage_stats[stat] or {}).get('data', {}).get('result', []):
@@ -635,7 +678,7 @@ def collect_and_send_otel_pod_node_usage(prometheus_url: str, labels: dict) -> N
         mem_min_query = mem_avg_query.replace("avg_over_time", "min_over_time")
         mem_max_query = mem_avg_query.replace("avg_over_time", "max_over_time")
         def get_stat(query):
-            data = query_prometheus(prometheus_url, query)
+            data = query_prometheus(prometheus_url, query, username, password)
             try:
                 if data and 'result' in data['data'] and data['data']['result']:
                     return float(data['data']['result'][0]['value'][1])
@@ -731,12 +774,20 @@ def main() -> None:
     
     # Get configuration from environment
     prometheus_url = os.getenv('PROMETHEUS_URL')
+    namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
 
-    # Collect and send data to Loki
-    collect_and_send_version_data(prometheus_url, labels)
-    collect_and_send_grafana_usage(prometheus_url, labels)
-    collect_and_send_otel_pod_node_usage(prometheus_url, labels)
-    collect_and_send_grafana_db_lock_errors(labels)
+    # Discover tenants dynamically from k8s secrets (empty list = single-tenant mode)
+    prometheus_tenants = get_tenant_credentials(namespace, 'metricsservice')
+    loki_tenants = get_tenant_credentials(namespace, 'logsservice')
+
+    # Prometheus collections — run per tenant (or once in single-tenant mode)
+    for credentials in (prometheus_tenants or [None]):
+        collect_and_send_version_data(prometheus_url, labels, credentials)
+        collect_and_send_grafana_usage(prometheus_url, labels, credentials)
+        collect_and_send_otel_pod_node_usage(prometheus_url, labels, credentials)
+
+    # Loki collections — run per tenant (or once in single-tenant mode)
+    collect_and_send_grafana_db_lock_errors(labels, loki_tenants or None)
     
     logger.info("Completed monitoring data collection")
 

--- a/observability/otel-observability.py
+++ b/observability/otel-observability.py
@@ -438,17 +438,16 @@ def query_loki(loki_url: str, query: str, username: Optional[str] = None, passwo
         return None
 
 
-def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str]) -> None:
+def collect_and_send_grafana_db_lock_errors(labels: Dict[str, str], credentials: Optional[Dict[str, str]] = None) -> None:
     """
     Count 'database is locked' errors in grafana-ui logs over the last 24h and send to central Loki.
-    Source Loki credentials from SOURCE_LOKI_USERNAME / SOURCE_LOKI_PASSWORD env vars (optional).
     """
     logger.info("Collecting and sending Grafana DB lock error data")
 
     namespace = labels.get('namespace') or os.getenv('NAMESPACE', '')
     service = 'grafana-ui'
-    username = os.getenv('SOURCE_LOKI_USERNAME', '').strip() or None
-    password = os.getenv('SOURCE_LOKI_PASSWORD', '').strip() or None
+    username = credentials.get('username') if credentials else None
+    password = credentials.get('password') if credentials else None
 
     source_loki_url = os.getenv('SOURCE_LOKI_URL') or f"http://duplo-logging-gateway.{namespace}.svc.cluster.local"
     query = f'sum(count_over_time({{namespace="{namespace}", service_name="{service}"}} |= `database is locked` != `logger=tsdb` [24h]))'
@@ -720,11 +719,15 @@ def main() -> None:
     prom_pass = os.getenv('SOURCE_PROMETHEUS_PASSWORD', '').strip()
     prometheus_creds = {'username': prom_user, 'password': prom_pass} if prom_user and prom_pass else None
 
+    loki_user = os.getenv('SOURCE_LOKI_USERNAME', '').strip()
+    loki_pass = os.getenv('SOURCE_LOKI_PASSWORD', '').strip()
+    loki_creds = {'username': loki_user, 'password': loki_pass} if loki_user and loki_pass else None
+
     # Collect and send data
     collect_and_send_version_data(prometheus_url, labels, prometheus_creds)
     collect_and_send_grafana_usage(prometheus_url, labels, prometheus_creds)
     collect_and_send_otel_pod_node_usage(prometheus_url, labels, prometheus_creds)
-    collect_and_send_grafana_db_lock_errors(labels)
+    collect_and_send_grafana_db_lock_errors(labels, loki_creds)
     
     logger.info("Completed monitoring data collection")
 


### PR DESCRIPTION
## Summary
- Adds `query_loki()` function to query source Loki using the in-cluster `duplo-logging-gateway` service
- Adds `collect_and_send_grafana_db_lock_errors()` which counts `database is locked` errors in `grafana-ui` logs over the last 24h using an instant LogQL query
- Pushes the count as a single data point to central Loki daily with stream labels `job=grafana_db_lock_errors`, `type=db_lock_error_count_24h`
- Uses `!= \`logger=tsdb\`` to exclude Grafana's own internal query execution logs from the count

## Query
```
sum(count_over_time({namespace="<NAMESPACE>", service_name="grafana-ui"} |= `database is locked` != `logger=tsdb` [24h]))
```

## Central Loki payload
```json
{"namespace": "<namespace>", "service": "grafana-ui", "db_lock_error_count_24h": <count>}
```

## Grafana dashboard query
```
last_over_time({job="grafana_db_lock_errors"} | json | unwrap db_lock_error_count_24h [24h]) by (cluster, customer, environment)
```

## Test plan
- [x] Tested on `test24-nonprod` cluster — Loki query returns HTTP 200, central Loki push returns HTTP 204
- [x] Verified `!= \`logger=tsdb\`` correctly excludes Grafana internal query logs
- [x] Count of 0 is sent when no errors found (healthy baseline)